### PR TITLE
Typo in the license field

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "mochify"
   },
   "author": "Deema Ywanov <dfcreative@gmail.com>",
-  "license": "Unlicensed",
+  "license": "Unlicense",
   "dependencies": {
     "arr-flatten": "^1.0.0",
     "sliced": "0.0.5",


### PR DESCRIPTION
Correcting a typo in the license field to change it to Unlicense instead of Unlicensed.